### PR TITLE
[RFR] Add battery_state message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_bson_binds(BSON_BIND_INCLUDES
   src/servo_states.bsonbind
   src/digital_states.bsonbind
   src/analog_states.bsonbind
+  src/battery_state.bsonbind
 )
 
 SET(BSON_BIND_INCLUDES_TMP "")

--- a/src/battery_state.bsonbind
+++ b/src/battery_state.bsonbind
@@ -1,0 +1,2 @@
+%package battlecreek
+real32 capacity!


### PR DESCRIPTION
This message will be used by https://github.com/kipr/battlehill/pull/1

It is probably our first use of a float value.
